### PR TITLE
changes for approving and denying coaches

### DIFF
--- a/src/app/(admin)/(others-pages)/(coaches)/coach/[id]/page.tsx
+++ b/src/app/(admin)/(others-pages)/(coaches)/coach/[id]/page.tsx
@@ -481,29 +481,31 @@ setCoach((prev) => {
 
           {/* Download Buttons */}
           <div className="flex flex-col items-center sm:items-end lg:items-end space-y-2">
-   <div className="flex space-x-2">
-      {coach.approved_or_denied === 1 ? (
-        // ✅ Already approved → show Decline only
-        <button
-          className="px-3 py-1 bg-red-500 text-white rounded hover:bg-red-600 transition flex items-center space-x-2"
-          onClick={() => handleCoachApproval(Number(coach.id), "decline")}
-          disabled={loadingId === Number(coach.id)} // disable button while loading
-        >
-          {loadingId === Number(coach.id) && <FaSpinner className="animate-spin" />}
-          <span>Decline</span>
-        </button>
-      ) : coach.approved_or_denied === 2 || coach.approved_or_denied === 0 ? (
-        // ✅ Declined or Pending → show Approve only
-        <button
-          className="px-3 py-1 bg-green-500 text-white rounded hover:bg-green-600 transition flex items-center space-x-2"
-          onClick={() => handleCoachApproval(Number(coach.id), "approve")}
-          disabled={loadingId === Number(coach.id)} // disable button while loading
-        >
-          {loadingId === Number(coach.id) && <FaSpinner className="animate-spin" />}
-          <span>Approve</span>
-        </button>
-      ) : null}
-    </div>
+
+            <div className="flex space-x-2">
+              {coach.approved_or_denied === 0 && (
+                <>
+                  {/* // ✅ Already approved → show Decline only */}
+                  <button
+                    className="px-3 py-1 bg-red-500 text-white rounded hover:bg-red-600 transition flex items-center space-x-2"
+                    onClick={() => handleCoachApproval(Number(coach.id), "decline")}
+                    disabled={loadingId === Number(coach.id)} // disable button while loading
+                  >
+                    {loadingId === Number(coach.id) && <FaSpinner className="animate-spin" />}
+                    <span>Decline</span>
+                  </button>
+                  {/* // ✅ Declined or Pending → show Approve only */}
+                  <button
+                    className="px-3 py-1 bg-green-500 text-white rounded hover:bg-green-600 transition flex items-center space-x-2"
+                    onClick={() => handleCoachApproval(Number(coach.id), "approve")}
+                    disabled={loadingId === Number(coach.id)} // disable button while loading
+                  >
+                    {loadingId === Number(coach.id) && <FaSpinner className="animate-spin" />}
+                    <span>Approve</span>
+                  </button>
+                </>
+              )}
+            </div>
 
 
 

--- a/src/app/(admin)/(others-pages)/(coaches)/newcoach/page.tsx
+++ b/src/app/(admin)/(others-pages)/(coaches)/newcoach/page.tsx
@@ -21,8 +21,8 @@ const CoachesPage = () => {
       setError(null);
       try {
       const response = await fetch(
-  `/api/coach/newcoach?search=${encodeURIComponent(searchQuery)}&page=${currentPage}&limit=10`
-);
+        `/api/coach/newcoach?search=${encodeURIComponent(searchQuery)}&page=${currentPage}&limit=10`
+      );
 
 
         if (!response.ok) throw new Error("Failed to fetch coaches");

--- a/src/app/api/coach/newcoach/route.ts
+++ b/src/app/api/coach/newcoach/route.ts
@@ -79,13 +79,14 @@ export async function GET(req: NextRequest) {
     const condition = search?.trim()
       ? and(
           eq(coaches.approved_or_denied, 0),
+          eq(coaches.isCompletedProfile, true),
           or(
             ilike(coaches.firstName, `%${search}%`),
             ilike(coaches.lastName, `%${search}%`),
             ilike(coaches.email, `%${search}%`)
           )
         )
-      : eq(coaches.approved_or_denied, 0);
+      : and(eq(coaches.approved_or_denied, 0), eq(coaches.isCompletedProfile, true));
 
     // Fetch total count for pagination
     const totalCoaches = await db

--- a/src/layout/AppSidebar.tsx
+++ b/src/layout/AppSidebar.tsx
@@ -91,7 +91,7 @@ const AppSidebar: React.FC = () => {
           {
             name: "Coaches",
             icon: <ListIcon />,
-            subItems: [{ name: "New Coach", path: "/newcoach", pro: false },
+            subItems: [{ name: "Unapproved Coach", path: "/newcoach", pro: false },
             { name: "Incomplete Coaches", path: "/incompletecoach", pro: false },
             { name: "Active Coach", path: "/coach", pro: false },
             { name: "Decline Coach", path: "/declinecoach", pro: false },
@@ -219,8 +219,10 @@ const AppSidebar: React.FC = () => {
           {
             name: "Coaches",
             icon: <ListIcon />,
-            subItems: [{name: "Incomplete Coaches", path:"/incompletecoach", pro:false},
+            subItems: [ {name: "Unapproved Coach", path: "/newcoach", pro: false},
+            {name: "Incomplete Coaches", path:"/incompletecoach", pro:false},
             { name: "Active Coach", path: "/coach", pro: false },
+            { name: "Decline Coach", path: "/declinecoach", pro: false},
             { name: "Suspended Coach", path: "/suspend", pro: false },
             { name: "Disable Coach", path: "/disablecoach", pro: false },
             ],


### PR DESCRIPTION
1.) Fixed bug where the api that retreives coaches who haven't approved or denied also retrieve the ones who haven't completed their profile yet

2.) Fixed a bug where coaches who have been approved will see the deny button and vice versa, when the buttons should only appear when the coaches hasn't been either approved or denied

3.) Renamed New Coach to Unapproved coach

4.) Executive can now see unapproved and denied coaches